### PR TITLE
Check client version iif not given

### DIFF
--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -204,11 +204,16 @@ class KafkaAdminClient(object):
         self._client = KafkaClient(metrics=self._metrics,
                                    metric_group_prefix='admin',
                                    **self.config)
-        self._client.check_version()
 
         # Get auto-discovered version from client if necessary
         if self.config['api_version'] is None:
             self.config['api_version'] = self._client.config['api_version']
+            if self.config['api_version_auto_timeout_ms'] is None:
+                self._client.check_version()
+            else:
+                # check_version timeout is is seconds
+                self._client.check_version(
+                    self.config['api_version_auto_timeout_ms'] / 1000)
 
         self._closed = False
         self._refresh_controller_id()


### PR DESCRIPTION
The docstring states the `api_version` and `api_version_auto_timeout_ms` are used to decide if check_version() has to be called and for how long it has to wait, now the function follows that behavior, consistent with the `KafkaClient`.

This could help with problems like #1308